### PR TITLE
Revert Build Output Directory

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -9,8 +9,6 @@ const config = {
 
   kit: {
     adapter: adapter({
-      pages: 'docs',
-      assets: 'docs',
       fallback: null,
       precompress: false,
       strict: true,


### PR DESCRIPTION
Change the build output directory from `docs` to default `build`.